### PR TITLE
Add a game profile property to identify NPCs

### DIFF
--- a/paper/src/main/java/net/minelink/ctplus/nms/NpcPlayer.java
+++ b/paper/src/main/java/net/minelink/ctplus/nms/NpcPlayer.java
@@ -33,6 +33,8 @@ public class NpcPlayer extends ServerPlayer {
             gameProfile.getProperties().put(entry.getKey(), entry.getValue());
         }
 
+        gameProfile.getProperties().put("is-cbtp-npc", true);
+
         NpcPlayer npcPlayer = new NpcPlayer(minecraftServer, worldServer, gameProfile);
         npcPlayer.identity = new NpcIdentity(player);
 


### PR DESCRIPTION
There's currently no way for the client to distinguish NPCs from real players due to the requirement of a random UUID.

Any mods on the client attempting to keep track of players will find that a single username can have multiple UUIDs because of this.

PR adds a single property to the NPC's game profile identifying them as an NPC.