### PR TITLE
Make NPCs use a V3 UUID to prevent collisions when generating UUIDs

### DIFF
--- a/paper/src/main/java/net/minelink/ctplus/nms/NpcPlayer.java
+++ b/paper/src/main/java/net/minelink/ctplus/nms/NpcPlayer.java
@@ -27,7 +27,7 @@ public class NpcPlayer extends ServerPlayer {
     public static NpcPlayer valueOf(Player player) {
         MinecraftServer minecraftServer = MinecraftServer.getServer();
         ServerLevel worldServer = ((CraftWorld) player.getWorld()).getHandle();
-        GameProfile gameProfile = new GameProfile(UUID.randomUUID(), NpcNameGeneratorFactory.getNameGenerator().generate(player));
+        GameProfile gameProfile = new GameProfile(UUID.nameUUIDFromBytes(UUID.randomUUID().toString().getBytes()), NpcNameGeneratorFactory.getNameGenerator().generate(player));
 
         for (Map.Entry<String, Property> entry: ((CraftPlayer) player).getProfile().getProperties().entries()) {
             gameProfile.getProperties().put(entry.getKey(), entry.getValue());


### PR DESCRIPTION
Prevents collisions with player UUIDs which are always version 4.

Additionally will allow clients to identify if a UUID associated with a player is a real UUID, or a fake one assigned to an NPC.