### PR TITLE
Discard player entities before adding them as NPCs

### DIFF
--- a/paper/src/main/java/net/minelink/ctplus/nms/NpcPlayer.java
+++ b/paper/src/main/java/net/minelink/ctplus/nms/NpcPlayer.java
@@ -27,7 +27,7 @@ public class NpcPlayer extends ServerPlayer {
     public static NpcPlayer valueOf(Player player) {
         MinecraftServer minecraftServer = MinecraftServer.getServer();
         ServerLevel worldServer = ((CraftWorld) player.getWorld()).getHandle();
-        GameProfile gameProfile = new GameProfile(UUID.randomUUID(), NpcNameGeneratorFactory.getNameGenerator().generate(player));
+        GameProfile gameProfile = new GameProfile(player.getUniqueId(), NpcNameGeneratorFactory.getNameGenerator().generate(player));
 
         for (Map.Entry<String, Property> entry: ((CraftPlayer) player).getProfile().getProperties().entries()) {
             gameProfile.getProperties().put(entry.getKey(), entry.getValue());

--- a/paper/src/main/java/net/minelink/ctplus/nms/NpcPlayerHelperImpl.java
+++ b/paper/src/main/java/net/minelink/ctplus/nms/NpcPlayerHelperImpl.java
@@ -16,6 +16,7 @@ import net.minecraft.network.protocol.game.ClientboundSetEquipmentPacket;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.food.FoodData;
 import net.minecraft.world.item.ItemStack;
@@ -47,6 +48,7 @@ public class NpcPlayerHelperImpl implements NpcPlayerHelper {
             serverPlayer.connection.send(packet);
         }
 
+        worldServer.entityManager.getEntityGetter().get(player.getUniqueId()).remove(Entity.RemovalReason.DISCARDED);
         worldServer.entityManager.addNewEntity(npcPlayer);
 
         return npcPlayer.getBukkitEntity();


### PR DESCRIPTION
Maintains a consistent UUID for players who have combat logged, eliminating the ability for someone to identify a combat logger by their UUID being real or not, and gives the NPC the player's skin as opposed to Steve/Alex